### PR TITLE
Add ca-certificates as build dependency

### DIFF
--- a/.github/workflows/deb-builder.yml
+++ b/.github/workflows/deb-builder.yml
@@ -12,5 +12,4 @@ jobs:
           buildpackage-opts: --build=binary --no-sign
           host-arch: arm64
           apt-opts: --install-recommends
-          extra-build-deps: ca-certificates
 

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Leonardo Held <leonardo.held@toradex.com>
 Build-Depends: debhelper (>= 9),
+               ca-certificates,
                lsb-release,
                wget
 Standards-Version: 4.5.1


### PR DESCRIPTION
We need because we download something from an https website during the build.

This has the nice side effect of making it buildable with sbuild now.